### PR TITLE
fix(site): supprime l'option de Matomo supposée gérer les cas où JS est désactivé

### DIFF
--- a/content/theme/partials/integrations/analytics/matomo.html
+++ b/content/theme/partials/integrations/analytics/matomo.html
@@ -15,7 +15,3 @@
         g.async = true; g.src = u + 'matomo.js'; s.parentNode.insertBefore(g, s);
     })();
 </script>
-<noscript>
-    <p><img referrerpolicy="no-referrer-when-downgrade" src="https://matomo.data-wax.com/matomo.php?idsite=5&amp;rec=1"
-            style="border:0;" alt="" /></p>
-</noscript>


### PR DESCRIPTION
Le truc relou qui ajoutait pépouze un `<p>` en haut du site même quand JS n'est pas désactivé :facepalm: 

<img width="1837" height="538" alt="image" src="https://github.com/user-attachments/assets/3fd0f371-3bb7-4ac7-9017-1b148eb39190" />
